### PR TITLE
Fixed so that cargo is only shown on allied vehicles

### DIFF
--- a/OpenRA.Game/Traits/SelectionDecorations.cs
+++ b/OpenRA.Game/Traits/SelectionDecorations.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Traits
 
 		public IEnumerable<IRenderable> RenderAfterWorld(WorldRenderer wr)
 		{
-			if (!self.Owner.IsAlliedWith(self.World.RenderPlayer) && self.World.FogObscures(self))
+			if (!self.Owner.IsAlliedWith(self.World.RenderPlayer) || self.World.FogObscures(self))
 				yield break;
 
 			var b = self.Bounds;


### PR DESCRIPTION
Fixed issue delftswa2014/team-OpenRA#3 so that only allied pips are shown. Can some of you check this? @joostverdoorn @jabbink @besuikerd ?

Question, this can be merged with our bleed branch (a.k.a unstable). But maybe it is a better idea to just check the code and once approved (by another team member), create a PR to the upstream. After the upstream is merged we can just fetch the upstream to stay up-to-date. The OpenRA team probably got a higher standard. Don't know if this is in spirit with the course? @rogierslag 
